### PR TITLE
 no custom user agent for logineonrw-messenger.de

### DIFF
--- a/Riot/Modules/Home/Fallback/AuthFallBackViewController.m
+++ b/Riot/Modules/Home/Fallback/AuthFallBackViewController.m
@@ -60,7 +60,16 @@ NSString *FallBackViewControllerJavascriptOnLogin = @"window.matrixLogin.onLogin
     
     // Due to https://developers.googleblog.com/2016/08/modernizing-oauth-interactions-in-native-apps.html, we hack
     // the user agent to bypass the limitation of Google, as a quick fix (a proper solution will be to use the SSO SDK)
-    webView.customUserAgent = @"Mozilla/5.0";
+    // Do not use the custom user agent when opening a logineonrw page. This (logineonrw) fix is only needed for iOS 12 and below.
+    if (@available(iOS 13, *)) {
+        // iOS 13 (or newer) ObjC code
+         webView.customUserAgent = @"Mozilla/5.0";
+    } else {
+        // iOS 12 or older code
+        if ([self.URL rangeOfString:@"logineonrw-messenger.de/"].location == NSNotFound) {
+            webView.customUserAgent = @"Mozilla/5.0";
+        }
+    }
 
     [self clearCookies];
 }


### PR DESCRIPTION
Do not use the custom user agent when opening a logineonrw-messenger.de page. 
This (logineonrw) fix is only needed for iOS 12 and below.

### Pull Request Checklist

* [ ] I read the [contributing guide](https://github.com/vector-im/element-ios/blob/develop/CONTRIBUTING.md)
* [ ] UI change has been tested on both light and dark themes, in portrait and landscape orientations and on iPhone and iPad simulators
* [ ] Pull request is based on the develop branch
* [ ] Pull request updates [CHANGES.rst](https://github.com/vector-im/riot-ios/blob/develop/CHANGES.rst)
* [ ] Pull request includes screenshots or videos of UI changes
* [ ] Pull request includes a [sign off](https://github.com/matrix-org/synapse/blob/master/CONTRIBUTING.md#sign-off)
